### PR TITLE
[FIX] Timer shows '1s' as stretching ends, fixed key in instructions

### DIFF
--- a/front-end/src/components/StretchPlayer/PlayerVideoCarousel/Card.tsx
+++ b/front-end/src/components/StretchPlayer/PlayerVideoCarousel/Card.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactElement, useContext } from 'react';
+import React, { FunctionComponent, ReactElement, useContext } from 'react';
 import Timer from '../Timer';
 import { ContextType } from '../../../typings/storetype';
 import { GlobalStateContext } from '../../../store/reducers';
@@ -35,22 +35,40 @@ const Card: FunctionComponent<CardProps> = ({
 	const { globalState } = useContext(GlobalStateContext) as ContextType;
 	const initialTime = Math.floor(timeInterval / 1000);
 	// console.log('initial time', initialTime);
-	const timer = globalState.cardShownId === id ? <Timer initialTime={initialTime} /> : null;
-	return (
-		<ExtendedArticle data-interval={timeInterval}>
-			{timer}
-			<h3>{name}</h3>
-			<img key={id} src={imgSrc} alt={imgAlt} />
-			<p>
+	let content: any = null;
+	if (globalState.cardShownId === id) {
+		content = (
+			<ExtendedArticle key={id} data-interval={timeInterval}>
+				<Timer initialTime={initialTime} />
+				<h3>{name}</h3>
+				<img src={imgSrc} alt={imgAlt} />
 				<ExtendedOrderedList>
-					{stretchInstructions.map(instruction => (
-						<li>{instruction}</li>
+					{stretchInstructions.map((instruction, instructionIndex) => (
+						<li key={instructionIndex}>{instruction}</li>
 					))}
 				</ExtendedOrderedList>
-			</p>
-		</ExtendedArticle>
-	);
+			</ExtendedArticle>
+		);
+	}
+	//set timer artificially to 1
+	// needed because of the bug last stretch card swaps to the congratulations card when the seconds reaches 1 rather than 0.
+	// so we can artifically inject a 1
+	if (globalState.stretchComplete) {
+		content = (
+			<ExtendedArticle key={id} data-interval={timeInterval}>
+				<h3>1s</h3>
+				<h3>{name}</h3>
+				<img src={imgSrc} alt={imgAlt} />
+				<ExtendedOrderedList>
+					{stretchInstructions.map((instruction, instructionIndex) => {
+						return <li key={instructionIndex}>{instruction}</li>;
+					})}
+				</ExtendedOrderedList>
+			</ExtendedArticle>
+		);
+	}
+	return content;
 };
 
 // Prevents unnecessary renders. If the parent re-renders, the child (this Card) will not re-render unless it has changed
-export default Card;
+export default React.memo(Card);

--- a/front-end/src/components/StretchPlayer/StretchPlayer.tsx
+++ b/front-end/src/components/StretchPlayer/StretchPlayer.tsx
@@ -35,6 +35,11 @@ const HeaderSubTitle = styled.h2`
 	}
 `;
 
+const HeaderSubTitleHidden = styled(HeaderSubTitle)`
+	opacity: 0;
+	pointer-events: none;
+`;
+
 const ExtendedCarousel = styled(Carousel)`
 	max-height: 500px;
 
@@ -122,10 +127,16 @@ const StretchPlayer: FunctionComponent<StretchPlayerProps> = ({ routine }): Reac
 	const content = !!interval ? (
 		<>
 			<Header>
-				<HeaderTitle>Breathe</HeaderTitle>
-				<HeaderSubTitle>
-					Stretch {globalState.cardShownId}/{globalState.cards.length}
-				</HeaderSubTitle>
+				<HeaderTitle>{globalState.selectedStretchRoutine}</HeaderTitle>
+				{!globalState.stretchComplete ? (
+					<HeaderSubTitle>
+						Stretch {globalState.cardShownId}/{globalState.cards.length - 1}
+					</HeaderSubTitle>
+				) : (
+					<HeaderSubTitleHidden>
+						Stretch {globalState.cardShownId}/{globalState.cards.length - 1}
+					</HeaderSubTitleHidden>
+				)}
 			</Header>
 			{/* <PlayerCurrentVideo />
 			<Deck /> */}

--- a/front-end/src/components/StretchPlayer/Timer/Timer.tsx
+++ b/front-end/src/components/StretchPlayer/Timer/Timer.tsx
@@ -20,10 +20,13 @@ const Timer: FunctionComponent<TimerProps> = ({ initialTime }): ReactElement => 
 			setTimeLeft(timeLeft - 1);
 		}, 1000);
 
-		if (timeLeft <= 1) {
-			if (globalState.cardShownId === globalState.lastCardId) {
+		if (globalState.cardShownId === globalState.lastCardId) {
+			if (timeLeft <= 1) {
 				globalActions.setStretchComplete();
 			}
+		}
+
+		if (timeLeft <= 0) {
 			clearTimeout(tick);
 			return;
 		}


### PR DESCRIPTION
+ Timer shows '1s' as stretching ends
+ Fixed key in instructions - it was showing that each stretch instruction had a non-unique key
+ Removed console.logs
+ Removed hard-coded 'Breathe' title